### PR TITLE
Improve the provider

### DIFF
--- a/src/main/java/io/openapitools/jackson/dataformat/hal/provider/DefaultObjectMapperProvider.java
+++ b/src/main/java/io/openapitools/jackson/dataformat/hal/provider/DefaultObjectMapperProvider.java
@@ -1,0 +1,30 @@
+package io.openapitools.jackson.dataformat.hal.provider;
+
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Provider
+@Produces(MediaType.WILDCARD)
+@Consumes(MediaType.WILDCARD)
+public class DefaultObjectMapperProvider implements ContextResolver<ObjectMapper> {
+    private final ObjectMapper mapper;
+
+    public DefaultObjectMapperProvider() {
+        this.mapper = createMapper();
+    }
+
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+        return mapper;
+    }
+
+    private ObjectMapper createMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/io/openapitools/jackson/dataformat/hal/provider/JacksonHALJsonProvider.java
+++ b/src/main/java/io/openapitools/jackson/dataformat/hal/provider/JacksonHALJsonProvider.java
@@ -1,39 +1,56 @@
 package io.openapitools.jackson.dataformat.hal.provider;
 
-import com.fasterxml.jackson.jaxrs.cfg.Annotations;
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-import io.openapitools.jackson.dataformat.hal.HALMapper;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jaxrs.cfg.Annotations;
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+
+import io.openapitools.jackson.dataformat.hal.HALMapper;
+import io.openapitools.jackson.dataformat.hal.JacksonHALModule;
+
 /**
- * Extension of the default {@link JacksonJsonProvider} to support the <code>application/hal+json</code> content type using {@link
- * HALMapper} enabling the {@link io.openapitools.jackson.dataformat.hal.JacksonHALModule}.
+ * Extension of the default {@link JacksonJsonProvider} to support the <code>application/hal+json</code> content type
+ * using an {@link ObjectMapper} configured with the {@link JacksonHALModule} (just like {@link HALMapper}).</br>
+ *</br>
+ * An {@link ObjectMapper} may already be provided through JAX-RS, usually through a provider class that
+ * implements {@link ContextResolver}<{@link ObjectMapper}>. Such an {@link ObjectMapper} may be configured differently
+ * and may still be used for plain JSON. So this provider will make a copy of that {@link ObjectMapper} and
+ * register {@link JacksonHALModule} on the copy, preserving any configuration that was copied over.
  */
 @Provider
 @Produces(JacksonHALJsonProvider.MEDIA_TYPE_APPLICATION_HAL_JSON)
 @Consumes(JacksonHALJsonProvider.MEDIA_TYPE_APPLICATION_HAL_JSON)
 public class JacksonHALJsonProvider extends JacksonJsonProvider {
-
-    /**
-     * Defining content type for JSON HAL
-     */
     public static final String MEDIA_TYPE_APPLICATION_HAL_JSON = "application/hal+json";
+    public static final JacksonHALModule JACKSON_HAL_MODULE = new JacksonHALModule();
 
-    /**
-     * Creating instance with default annotations which uses the {@link HALMapper}.
-     */
     public JacksonHALJsonProvider() {
-        super(new HALMapper());
+        this(null, BASIC_ANNOTATIONS);
     }
 
-    /**
-     * Creating instance with custom list of annotations which uses the {@link HALMapper}.
-     *
-     * @param annotationsToUse Sets of annotations (Jackson, JAXB) that provider should support
-     */
     public JacksonHALJsonProvider(Annotations[] annotationsToUse) {
-        super(new HALMapper(), annotationsToUse);
+        this(null, annotationsToUse);
+    }
+
+    public JacksonHALJsonProvider(ObjectMapper mapper) {
+        this(mapper == null ? mapper : mapper.registerModule(JACKSON_HAL_MODULE), BASIC_ANNOTATIONS);
+    }
+
+    public JacksonHALJsonProvider(ObjectMapper mapper, Annotations[] annotationsToUse) {
+        super(mapper == null ? mapper : mapper.registerModule(JACKSON_HAL_MODULE), annotationsToUse);
+    }
+
+    @Override
+    protected ObjectMapper _locateMapperViaProvider(Class<?> type, MediaType mediaType) {
+        ObjectMapper mapper = super._locateMapperViaProvider(type, mediaType);
+        if (mapper == null) {
+            return null;
+        }
+        return mapper.copy().registerModule(JACKSON_HAL_MODULE);
     }
 }


### PR DESCRIPTION
I've changed the provider so it can use the `ObjectMapper` provider through JAX-RS. I've tested that this works with a provider class that implements `ContextResolver<ObjectMapper>` to provide the `ObjectMapper`. 

The reason I registered `JacksonHALModule` on the `ObjectMapper` instead of using the `HALMapper` directly, is to preserve any configuration on the `ObjectMapper`. This is actually done quite often (like registering the Jackson `JavaTimeModule` on the mapper to support `ZonedDateTime` and such data types). Creating a new `HALMapper` in the provider would discard all of that custom configuration.

I also added a simple provider that implements `ContextResolver<ObjectMapper>`. This is just for convenience, so you can register the providers by class name instead of registering instances of those providers. But this just provides a default ObjectMapper. Most people will want to register their own version of this provider, with the `ObjectMapper` configured to suit their own needs. 